### PR TITLE
feat: add cpu opponent and improve graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# tenis-pocholo
+# Tenis Pocholo
+
+Arcade de tenis 2D donde perros salchicha intentan robar la pelota.
+
+## Requisitos
+- Python 3
+- pygame
+
+## Ejecución
+Instala las dependencias y ejecuta:
+
+```
+pip install pygame
+python main.py
+```
+
+Mueve al jugador con las flechas arriba/abajo y usa la barra espaciadora para recuperar la pelota cuando un perro la toma.

--- a/main.py
+++ b/main.py
@@ -2,20 +2,18 @@ import pygame
 import sys
 import random
 
-# Inicializa Pygame y sonidos
 pygame.init()
 WIDTH, HEIGHT = 1000, 600
 screen = pygame.display.set_mode((WIDTH, HEIGHT))
 pygame.display.set_caption("Tenis Pocholo: ¡Cuidado con los salchichas!")
 clock = pygame.time.Clock()
 
-# Sonidos (puedes cambiar por tus archivos en assets/)
 try:
     pygame.mixer.init()
     sound_score = pygame.mixer.Sound("assets/score.wav")
     sound_dog = pygame.mixer.Sound("assets/dog.wav")
     sound_recover = pygame.mixer.Sound("assets/recover.wav")
-except:
+except Exception:
     sound_score = sound_dog = sound_recover = None
 
 # Colores
@@ -23,109 +21,128 @@ GREEN = (34, 139, 34)
 WHITE = (255, 255, 255)
 RED = (200, 0, 0)
 BROWN = (139, 69, 19)
-BLACK = (0, 0, 0)
 YELLOW = (255, 255, 0)
 
-# Jugador
+# Jugadores
 player_img = pygame.Surface((60, 120), pygame.SRCALPHA)
 pygame.draw.ellipse(player_img, WHITE, [0, 0, 60, 120])
+player = pygame.Rect(60, HEIGHT // 2 - 60, 60, 120)
+player_speed = 10
+
+opponent_img = pygame.Surface((60, 120), pygame.SRCALPHA)
+pygame.draw.ellipse(opponent_img, WHITE, [0, 0, 60, 120])
+opponent = pygame.Rect(WIDTH - 120, HEIGHT // 2 - 60, 60, 120)
+opponent_speed = 7
 
 # Pelota
-ball = pygame.Rect(WIDTH//2-10, HEIGHT//2-10, 20, 20)
+ball = pygame.Rect(WIDTH // 2 - 10, HEIGHT // 2 - 10, 20, 20)
 ball_speed = [7, 7]
 
-# Perro salchicha
+# Perros salchicha
 dog_img = pygame.Surface((90, 40), pygame.SRCALPHA)
 pygame.draw.ellipse(dog_img, BROWN, [0, 0, 90, 40])
-pygame.draw.circle(dog_img, BROWN, (80, 20), 20) # Cabeza
-
+pygame.draw.circle(dog_img, BROWN, (80, 20), 20)
 dogs = []
-DOG_SPAWN_TIME = 120
+DOG_SPAWN_TIME = 180
 dog_timer = 0
-
-# Jugador
-player = pygame.Rect(50, HEIGHT//2-60, 60, 120)
-player_speed = 10
 
 # Estado de la pelota
 ball_taken = False
 dog_with_ball = None
 
 # Puntos
-score = 0
+player_score = 0
+opponent_score = 0
 font = pygame.font.SysFont("Arial", 40)
 
-# Menú de inicio
+# Menú
 game_state = "menu"
 
 def spawn_dog():
-    y = random.randint(60, HEIGHT-100)
+    y = random.randint(60, HEIGHT - 100)
     direction = random.choice([-1, 1])
-    if direction == -1:
-        x = WIDTH
-    else:
-        x = -90
-    dogs.append({'rect': pygame.Rect(x, y, 90, 40), 'dir': direction, 'has_ball': False})
+    x = WIDTH if direction == -1 else -90
+    dogs.append({"rect": pygame.Rect(x, y, 90, 40), "dir": direction, "has_ball": False})
 
-def reset_ball():
+def reset_ball(direction=None):
     global ball, ball_speed, ball_taken, dog_with_ball
-    ball.x, ball.y = WIDTH//2-10, HEIGHT//2-10
-    ball_speed = [random.choice([-7, 7]), random.choice([-7, 7])]
+    ball.x, ball.y = WIDTH // 2 - 10, HEIGHT // 2 - 10
+    ball_speed = [random.choice([-7, 7]) if direction is None else direction, random.choice([-7, 7])]
     ball_taken = False
     dog_with_ball = None
 
-def draw():
+def draw_court():
     screen.fill(GREEN)
-    pygame.draw.rect(screen, WHITE, [WIDTH//2-5, 0, 10, HEIGHT])
+    pygame.draw.rect(screen, WHITE, (50, 50, WIDTH - 100, HEIGHT - 100), 5)
+    pygame.draw.line(screen, WHITE, (WIDTH // 2, 50), (WIDTH // 2, HEIGHT - 50), 5)
+
+def draw():
+    draw_court()
     screen.blit(player_img, player)
+    screen.blit(opponent_img, opponent)
     for dog in dogs:
-        screen.blit(dog_img, dog['rect'])
-    if not ball_taken:
-        pygame.draw.ellipse(screen, RED, ball)
-    score_text = font.render(f"Puntos: {score}", True, YELLOW)
-    screen.blit(score_text, (WIDTH - 250, 30))
+        screen.blit(dog_img, dog["rect"])
+    pygame.draw.ellipse(screen, RED, ball)
+    score_text = font.render(f"Jugador: {player_score}  CPU: {opponent_score}", True, YELLOW)
+    screen.blit(score_text, (WIDTH // 2 - score_text.get_width() // 2, 20))
     pygame.display.flip()
 
 def draw_menu():
     screen.fill(GREEN)
     title = font.render("Tenis Pocholo", True, WHITE)
     subtitle = font.render("¡Cuidado con los salchichas!", True, YELLOW)
-    start_text = font.render("Presiona ENTER para jugar", True, BLACK)
-    screen.blit(title, (WIDTH//2 - title.get_width()//2, HEIGHT//2 - 100))
-    screen.blit(subtitle, (WIDTH//2 - subtitle.get_width()//2, HEIGHT//2 - 30))
-    screen.blit(start_text, (WIDTH//2 - start_text.get_width()//2, HEIGHT//2 + 80))
+    start_text = font.render("Presiona ENTER para jugar", True, BROWN)
+    screen.blit(title, (WIDTH // 2 - title.get_width() // 2, HEIGHT // 2 - 100))
+    screen.blit(subtitle, (WIDTH // 2 - subtitle.get_width() // 2, HEIGHT // 2 - 30))
+    screen.blit(start_text, (WIDTH // 2 - start_text.get_width() // 2, HEIGHT // 2 + 80))
     pygame.display.flip()
 
 def update_dogs():
     global ball_taken, dog_with_ball
-    for dog in dogs:
-        dog['rect'].x += dog['dir'] * 5
-        if dog['rect'].colliderect(ball) and not ball_taken:
+    for dog in dogs[:]:
+        dog["rect"].x += dog["dir"] * 5
+        if dog["rect"].colliderect(ball) and not ball_taken:
             ball_taken = True
-            dog['has_ball'] = True
+            dog["has_ball"] = True
             dog_with_ball = dog
-            if sound_dog: sound_dog.play()
-        if dog['rect'].x < -100 or dog['rect'].x > WIDTH+100:
+            if sound_dog:
+                sound_dog.play()
+        if dog["has_ball"]:
+            ball.center = dog["rect"].center
+        if dog["rect"].x < -100 or dog["rect"].x > WIDTH + 100:
             dogs.remove(dog)
+            if dog is dog_with_ball:
+                reset_ball(direction=random.choice([-7, 7]))
 
 def recover_ball():
     global ball_taken, dog_with_ball
-    if dog_with_ball and player.colliderect(dog_with_ball['rect']):
-        ball.x, ball.y = player.centerx, player.centery
+    if dog_with_ball and player.colliderect(dog_with_ball["rect"]):
+        ball.center = player.center
         ball_taken = False
-        dog_with_ball['has_ball'] = False
+        dog_with_ball["has_ball"] = False
         dog_with_ball = None
-        if sound_recover: sound_recover.play()
+        if sound_recover:
+            sound_recover.play()
 
-def add_score():
-    global score
-    score += 1
-    if sound_score: sound_score.play()
+def update_opponent():
+    if opponent.centery < ball.centery:
+        opponent.y += opponent_speed
+    elif opponent.centery > ball.centery:
+        opponent.y -= opponent_speed
+    opponent.y = max(0, min(opponent.y, HEIGHT - opponent.height))
+
+def add_score(left_side):
+    global player_score, opponent_score
+    if left_side:
+        opponent_score += 1
+    else:
+        player_score += 1
+    if sound_score:
+        sound_score.play()
 
 def game_loop():
-    global dog_timer, game_state, score
+    global dog_timer, game_state
     reset_ball()
-    score = 0
     while game_state == "playing":
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
@@ -142,11 +159,20 @@ def game_loop():
         if not ball_taken:
             ball.x += ball_speed[0]
             ball.y += ball_speed[1]
-            if ball.top <= 0 or ball.bottom >= HEIGHT:
+            if ball.top <= 50 or ball.bottom >= HEIGHT - 50:
                 ball_speed[1] *= -1
-            if ball.left <= 0 or ball.right >= WIDTH:
-                add_score()
-                reset_ball()
+            if ball.colliderect(player):
+                ball_speed[0] = abs(ball_speed[0])
+            if ball.colliderect(opponent):
+                ball_speed[0] = -abs(ball_speed[0])
+            if ball.left <= 50:
+                add_score(left_side=True)
+                reset_ball(direction=7)
+            if ball.right >= WIDTH - 50:
+                add_score(left_side=False)
+                reset_ball(direction=-7)
+
+        update_opponent()
 
         dog_timer += 1
         if dog_timer >= DOG_SPAWN_TIME:
@@ -168,7 +194,6 @@ def menu_loop():
             if event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN:
                 game_state = "playing"
 
-# Main loop
 while True:
     if game_state == "menu":
         menu_loop()


### PR DESCRIPTION
## Summary
- Add opponent paddle with simple AI and scoring
- Draw detailed tennis court and scoreboard
- Let dachshunds steal and carry the ball

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68991d65f608832fa8aa520cc06ef353