### PR TITLE
Add crowd and hit sounds with visual tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore binary audio assets
+*.wav
+assets/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 Arcade de tenis 2D donde perros salchicha intentan robar la pelota. Los jugadores
 portan raquetas, lucen flequillo y la pelota es amarilla fluorescente. Ahora la
-cancha incluye gradas con hinchada y un árbitro en el centro.
+cancha incluye gradas con hinchada, un árbitro al costado y rostros pixelados
+al estilo Double Dragon. Hay efectos de sonido generados por código tanto para
+los raquetazos a los perros como para la ovación del público al anotar un tanto,
+sin archivos de audio externos.
 
 ## Requisitos
 - Python 3


### PR DESCRIPTION
## Summary
- Generate crowd, dog, hit and recover sounds directly in code instead of shipping binary audio files
- Document programmatic sound effects and ignore audio assets in version control

## Testing
- `python -m py_compile main.py`
- `SDL_VIDEODRIVER=dummy timeout 5 python main.py`


------
https://chatgpt.com/codex/tasks/task_e_68992943c4a0832fa524f2093de966f3