### PR TITLE
Generate audio assets at runtime instead of using Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.wav filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Python cache files
 __pycache__/
 *.pyc
+
+# Generated audio assets
+assets/*.wav

--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ La ventana abre en 1280×720. Mueve al jugador con las flechas izquierda/derecha
 para desplazarte por la cancha y con arriba/abajo para acercarte o alejarte de
 la red. La pelota rebota en las paredes y cambia de lado al golpear las
 raquetas.
+
+Los sonidos de golpe y aplauso se generan automáticamente al iniciar el juego,
+por lo que no es necesario descargarlos previamente.

--- a/assets/applause.wav
+++ b/assets/applause.wav
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7e8a34444123410da18c0d76950273b800f166b72d82a25fab4cbb52a7148ec3
-size 44144

--- a/assets/hit.wav
+++ b/assets/hit.wav
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e8022ce7a1121c2b6b73516e7edd733fc1f2d511c22e9ea92e63bfe5189a0950
-size 8864

--- a/generate_assets.py
+++ b/generate_assets.py
@@ -2,6 +2,7 @@ import math
 import random
 import struct
 import wave
+from pathlib import Path
 
 SAMPLE_RATE = 44100
 
@@ -14,7 +15,9 @@ def generate_hit(path: str) -> None:
         struct.pack('<h', int(32767 * math.sin(2 * math.pi * freq * i / SAMPLE_RATE)))
         for i in range(int(SAMPLE_RATE * duration))
     ]
-    with wave.open(path, 'wb') as w:
+    out_path = Path(path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(out_path), 'wb') as w:
         w.setnchannels(1)
         w.setsampwidth(2)
         w.setframerate(SAMPLE_RATE)
@@ -28,7 +31,9 @@ def generate_applause(path: str) -> None:
         struct.pack('<h', int(32767 * random.uniform(-1, 1)))
         for _ in range(int(SAMPLE_RATE * duration))
     ]
-    with wave.open(path, 'wb') as w:
+    out_path = Path(path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(out_path), 'wb') as w:
         w.setnchannels(1)
         w.setsampwidth(2)
         w.setframerate(SAMPLE_RATE)

--- a/main.py
+++ b/main.py
@@ -1,10 +1,12 @@
 import sys
 import random
+from pathlib import Path
 
 import pygame
 from pygame.locals import DOUBLEBUF, OPENGL, K_DOWN, K_UP, K_LEFT, K_RIGHT
 from OpenGL.GL import *
 from OpenGL.GLU import *
+from generate_assets import generate_hit, generate_applause
 
 # Window resolution boosted for a clearer view of the court
 WIDTH, HEIGHT = 1280, 720
@@ -12,6 +14,14 @@ WIDTH, HEIGHT = 1280, 720
 # Dimensions of paddles and play field
 PADDLE_WIDTH, PADDLE_HEIGHT, PADDLE_DEPTH = 1.0, 2.0, 0.3
 COURT_HALF_WIDTH, COURT_HALF_DEPTH = 5.0, 7.0
+
+ASSETS_DIR = Path("assets")
+HIT_FILE = ASSETS_DIR / "hit.wav"
+APPLAUSE_FILE = ASSETS_DIR / "applause.wav"
+if not HIT_FILE.exists():
+    generate_hit(str(HIT_FILE))
+if not APPLAUSE_FILE.exists():
+    generate_applause(str(APPLAUSE_FILE))
 
 
 def init() -> None:
@@ -206,8 +216,8 @@ def main():
     player_score = opponent_score = 0
 
     font = pygame.font.SysFont(None, 48)
-    hit_sound = pygame.mixer.Sound("assets/hit.wav")
-    score_sound = pygame.mixer.Sound("assets/applause.wav")
+    hit_sound = pygame.mixer.Sound(str(HIT_FILE))
+    score_sound = pygame.mixer.Sound(str(APPLAUSE_FILE))
 
     while True:
         for event in pygame.event.get():


### PR DESCRIPTION
## Summary
- Remove Git LFS-tracked audio and generate hit/applause sounds programmatically when missing
- Ignore generated `.wav` files and document automatic audio generation
- Ensure asset generator creates output directories before writing

## Testing
- `python -m py_compile main.py generate_assets.py`
- `python generate_assets.py`
- `pip install pygame PyOpenGL`
- `python main.py` *(fails: ImportError: Unable to find an OpenGL or GL library)*

------
https://chatgpt.com/codex/tasks/task_e_689a753e2084832facc8047247b52030