### PR TITLE
Add serving, crowd, and dog mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ Instala las dependencias y ejecuta:
 
 La ventana abre en 1280×720. Mueve al jugador con las flechas izquierda/derecha
 para desplazarte por la cancha y con arriba/abajo para acercarte o alejarte de
-la red. La pelota rebota en las paredes y cambia de lado al golpear las
-raquetas.
+la red. Con la barra espaciadora golpeas la pelota y sacas. El marcador se
+muestra en pantalla y se anuncia cuando saca la CPU. La cancha es de color
+naranja ladrillo y en los laterales se ven las tribunas. De vez en cuando
+aparecen perros salchicha intentando robar la pelota: ¡ahuyéntalos con un
+raquetazo usando la misma tecla de golpe!
 
 Los sonidos de golpe y aplauso se generan automáticamente al iniciar el juego,
 por lo que no es necesario descargarlos previamente.

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import random
 from pathlib import Path
 
 import pygame
-from pygame.locals import DOUBLEBUF, OPENGL, K_DOWN, K_UP, K_LEFT, K_RIGHT
+from pygame.locals import DOUBLEBUF, OPENGL, K_DOWN, K_UP, K_LEFT, K_RIGHT, K_SPACE
 from OpenGL.GL import *
 from OpenGL.GLU import *
 from generate_assets import generate_hit, generate_applause
@@ -42,7 +42,7 @@ def init() -> None:
 def draw_court() -> None:
     """Render the floor, boundaries and a basic 3D net."""
     # Floor
-    glColor3f(0, 0.5, 0)
+    glColor3f(0.9, 0.4, 0.1)
     glBegin(GL_QUADS)
     glVertex3f(-COURT_HALF_WIDTH, 0, -COURT_HALF_DEPTH)
     glVertex3f(COURT_HALF_WIDTH, 0, -COURT_HALF_DEPTH)
@@ -127,6 +127,22 @@ def draw_box(x: float, y: float, z: float, w: float, h: float, d: float, color: 
     glEnd()
 
 
+def draw_stands() -> None:
+    """Draw simple stands with a cheering crowd along the sidelines."""
+    # Stands structures
+    stand_color = (0.3, 0.3, 0.3)
+    draw_box(-COURT_HALF_WIDTH - 1.5, 1.5, 0, 2.0, 3.0, COURT_HALF_DEPTH * 2 + 2, stand_color)
+    draw_box(COURT_HALF_WIDTH + 1.5, 1.5, 0, 2.0, 3.0, COURT_HALF_DEPTH * 2 + 2, stand_color)
+
+    # Simple crowd blocks with random colors to simulate cheering
+    for side in (-COURT_HALF_WIDTH - 1.5, COURT_HALF_WIDTH + 1.5):
+        z = -COURT_HALF_DEPTH
+        while z <= COURT_HALF_DEPTH:
+            crowd_color = (random.random(), random.random(), random.random())
+            draw_box(side, 1.5, z, 1.8, 1.0, 0.8, crowd_color)
+            z += 2.0
+
+
 def draw_ball(position: list[float]) -> None:
     """Draw the tennis ball with a smoother sphere."""
     glColor3f(1, 1, 0)
@@ -200,10 +216,34 @@ def draw_player(position: list[float], color: tuple[float, float, float]) -> Non
     glPopMatrix()
 
 
-def reset_ball(ball_pos, ball_speed):
-    ball_pos[:] = [0.0, 1.5, 0.0]
-    direction = random.choice([-1, 1])
-    ball_speed[:] = [0.1 * direction, 0.05, 0.2 * direction]
+class Dog:
+    """Simple dachshund chasing the ball."""
+
+    def __init__(self, x: float, z: float) -> None:
+        self.x = x
+        self.z = z
+        self.speed = 0.05
+
+    def move_towards(self, target: list[float]) -> None:
+        dx = target[0] - self.x
+        dz = target[2] - self.z
+        dist = max((dx * dx + dz * dz) ** 0.5, 0.001)
+        self.x += self.speed * dx / dist
+        self.z += self.speed * dz / dist
+
+    def draw(self) -> None:
+        draw_box(self.x, 0.25, self.z, 1.0, 0.5, 0.3, (0.6, 0.3, 0.1))
+
+
+def reset_ball(ball_pos, ball_speed, server, player_pos, opponent_pos):
+    if server == "player":
+        ball_pos[:] = [player_pos[0], 1.5, player_pos[2] - PADDLE_DEPTH]
+        ball_speed[:] = [0.0, 0.0, 0.0]
+        return True
+    else:
+        ball_pos[:] = [opponent_pos[0], 1.5, opponent_pos[2] + PADDLE_DEPTH]
+        ball_speed[:] = [0.1 * random.choice([-1, 1]), 0.05, 0.2]
+        return False
 
 
 def main():
@@ -212,18 +252,25 @@ def main():
     player_pos = [0.0, 1.5, COURT_HALF_DEPTH - 0.5]
     opponent_pos = [0.0, 1.5, -COURT_HALF_DEPTH + 0.5]
     ball_pos = [0.0, 1.5, 0.0]
-    ball_speed = [0.1, 0.05, 0.2]
+    ball_speed = [0.0, 0.0, 0.0]
     player_score = opponent_score = 0
+    server = "opponent"
+    waiting_for_serve = reset_ball(ball_pos, ball_speed, server, player_pos, opponent_pos)
+    opponent_serving_timer = 120
+    dogs: list[Dog] = []
 
     font = pygame.font.SysFont(None, 48)
     hit_sound = pygame.mixer.Sound(str(HIT_FILE))
     score_sound = pygame.mixer.Sound(str(APPLAUSE_FILE))
 
     while True:
+        space_pressed = False
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 pygame.quit()
                 sys.exit()
+            if event.type == pygame.KEYDOWN and event.key == K_SPACE:
+                space_pressed = True
 
         keys = pygame.key.get_pressed()
         if keys[K_LEFT] and player_pos[0] > -COURT_HALF_WIDTH + PADDLE_WIDTH / 2:
@@ -239,51 +286,98 @@ def main():
             opponent_pos[0] += 0.1
         elif opponent_pos[0] - 0.1 > ball_pos[0]:
             opponent_pos[0] -= 0.1
-        opponent_pos[0] = max(-COURT_HALF_WIDTH + PADDLE_WIDTH / 2, min(COURT_HALF_WIDTH - PADDLE_WIDTH / 2, opponent_pos[0]))
+        opponent_pos[0] = max(
+            -COURT_HALF_WIDTH + PADDLE_WIDTH / 2,
+            min(COURT_HALF_WIDTH - PADDLE_WIDTH / 2, opponent_pos[0]),
+        )
 
-        for i in range(3):
-            ball_pos[i] += ball_speed[i]
+        # Spawn dogs on player's side
+        if not waiting_for_serve and ball_pos[2] > 0 and random.random() < 0.01:
+            spawn_z = random.uniform(0, COURT_HALF_DEPTH)
+            spawn_x = random.choice([-COURT_HALF_WIDTH - 1.5, COURT_HALF_WIDTH + 1.5])
+            dogs.append(Dog(spawn_x, spawn_z))
+
+        if not waiting_for_serve:
+            for i in range(3):
+                ball_pos[i] += ball_speed[i]
         if ball_pos[1] >= 3.5 or ball_pos[1] <= 0.5:
             ball_speed[1] *= -1
 
-        if (
+        # Dogs chase the ball
+        for dog in dogs[:]:
+            dog.move_towards(ball_pos)
+            if ((dog.x - ball_pos[0]) ** 2 + (dog.z - ball_pos[2]) ** 2) ** 0.5 < 0.5:
+                waiting_for_serve = reset_ball(ball_pos, ball_speed, "player", player_pos, opponent_pos)
+                dogs.remove(dog)
+            elif space_pressed and ((dog.x - player_pos[0]) ** 2 + (dog.z - player_pos[2]) ** 2) ** 0.5 < 1.5:
+                dogs.remove(dog)
+                hit_sound.play()
+
+        player_hit = (
             ball_pos[2] >= player_pos[2] - PADDLE_DEPTH
             and ball_pos[2] <= player_pos[2]
             and abs(ball_pos[0] - player_pos[0]) <= PADDLE_WIDTH
             and abs(ball_pos[1] - 1.5) <= PADDLE_HEIGHT / 2
-        ):
-            ball_speed[2] *= -1
+        )
+        if player_hit and space_pressed:
+            ball_speed[2] = -abs(ball_speed[2])
             hit_sound.play()
-        if (
+
+        opponent_hit = (
             ball_pos[2] <= opponent_pos[2] + PADDLE_DEPTH
             and ball_pos[2] >= opponent_pos[2]
             and abs(ball_pos[0] - opponent_pos[0]) <= PADDLE_WIDTH
             and abs(ball_pos[1] - 1.5) <= PADDLE_HEIGHT / 2
-        ):
-            ball_speed[2] *= -1
+        )
+        if opponent_hit:
+            ball_speed[2] = abs(ball_speed[2])
             hit_sound.play()
 
         if ball_pos[2] > COURT_HALF_DEPTH:
             opponent_score += 1
             score_sound.play()
-            reset_ball(ball_pos, ball_speed)
+            server = "opponent"
+            waiting_for_serve = reset_ball(ball_pos, ball_speed, server, player_pos, opponent_pos)
+            opponent_serving_timer = 120
+            dogs.clear()
         elif ball_pos[2] < -COURT_HALF_DEPTH:
             player_score += 1
             score_sound.play()
-            reset_ball(ball_pos, ball_speed)
+            server = "player"
+            waiting_for_serve = reset_ball(ball_pos, ball_speed, server, player_pos, opponent_pos)
+            dogs.clear()
 
-        pygame.display.set_caption(f"Tenis Pocholo 3D - {player_score} : {opponent_score}")
+        if waiting_for_serve and space_pressed:
+            ball_speed[:] = [0.1 * random.choice([-1, 1]), 0.05, -0.2]
+            waiting_for_serve = False
+            hit_sound.play()
+
+        pygame.display.set_caption(
+            f"Tenis Pocholo 3D - {player_score} : {opponent_score}"
+        )
 
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
         draw_court()
+        draw_stands()
         draw_player(player_pos, (0, 0, 1))
         draw_player(opponent_pos, (1, 0, 0))
         draw_ball(ball_pos)
+        for dog in dogs:
+            dog.draw()
 
         glDisable(GL_DEPTH_TEST)
-        score_text = font.render(f"Jugador {player_score} - CPU {opponent_score}", True, (255, 255, 255))
         screen = pygame.display.get_surface()
+        score_text = font.render(
+            f"Jugador {player_score} - CPU {opponent_score}", True, (255, 255, 255)
+        )
         screen.blit(score_text, (WIDTH // 2 - score_text.get_width() // 2, 20))
+        if waiting_for_serve:
+            msg = font.render("Tu saque - ESPACIO", True, (255, 255, 0))
+            screen.blit(msg, (WIDTH // 2 - msg.get_width() // 2, 60))
+        elif opponent_serving_timer > 0:
+            msg = font.render("CPU saca!", True, (255, 255, 0))
+            screen.blit(msg, (WIDTH // 2 - msg.get_width() // 2, 60))
+            opponent_serving_timer -= 1
         glEnable(GL_DEPTH_TEST)
 
         pygame.display.flip()


### PR DESCRIPTION
## Summary
- Add orange clay court and render stands with random-colored crowd
- Introduce dachshund dogs that chase the ball and can be swatted with spacebar
- Require spacebar to serve and return the ball with on-screen notices

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_689a77e46fcc832fa4f93d66d60c894c